### PR TITLE
Comments refactor and some addition methods

### DIFF
--- a/lib/OOIO/Exceptions.php
+++ b/lib/OOIO/Exceptions.php
@@ -8,8 +8,9 @@ class Exception extends \Exception
 class FileNotFoundException extends Exception
 {}
 
-# Exception which gets thrown if the End of a file
-# is reached unexpectedly.
+/** Exception which gets thrown if the End of a file
+ * is reached unexpectedly.
+ */
 class EofException extends Exception
 {}
 

--- a/lib/OOIO/IO.php
+++ b/lib/OOIO/IO.php
@@ -99,6 +99,23 @@ class IO
     }
 
     /**
+     * Memory or temp backed stream
+     * 
+     * @param $useTemp - TRUE to use temp backed stream php://temp
+     * @param $initWith - writes this string or stream to the newly created stream and rewinds it
+     * 
+     * @return Stream
+     */
+    public static function memory($useTemp = true, $initWith = null) {
+        $stream = static::open($useTemp ? "php://temp" : "php://memory", "w+b");
+        if ($initWith) {
+            $stream->write($initWith);
+            $stream->rewind();
+        }
+        return $stream;
+    }
+
+    /**
      * Returns information about the filename.
      *
      * @param $filename Filename as String.

--- a/lib/OOIO/IO.php
+++ b/lib/OOIO/IO.php
@@ -4,7 +4,9 @@ namespace OOIO;
 
 class IO
 {
-    # Returns the default stream context.
+    /**
+     * @return the default stream context.
+     */
     static function getDefaultContext()
     {
         static $context;
@@ -17,91 +19,111 @@ class IO
         return call_user_func($context);
     }
 
-    # Opens the given filename (URI) with the mode and
-    # returns a new Stream instance.
-    #
-    # filename
-    # mode
-    #
-    # Returns a Stream.
+    /** Opens the given filename (URI) with the mode and returns a new Stream instance.
+     * @param type $filename
+     * @param type $mode
+     * @param type $callback
+     * @return Stream
+     */
     static function open($filename, $mode = "", $callback = null)
     {
         return static::getDefaultContext()->open($filename, $mode, $callback);
     }
 
-    # Read the contents of the file into a String (binary safe). See
-    # StreamContext::read().
+    
+    /**
+     * Read the contents of the file into a String (binary safe). See
+     * StreamContext::read().
+     */
     static function read($filename, $maxLength = -1, $offset = -1)
     {
         return static::getDefaultContext()->read($filename, $maxLength, $offset);
     }
 
-    # Writes the data to the filename. See StreamContext::write().
+    /**
+     * Writes the data to the filename. See StreamContext::write().
+     */
     static function write($filename, $data, $flags = 0)
     {
         return static::getDefaultContext()->write($filename, $data, $flags);
     }
 
-    # Appends the content to the filename
-    #
-    # filename - Path to the file.
-    # data     - Data as String.
-    #
-    # Returns Number of Bytes written.
+    /**
+     * Appends the content to the filename
+     *
+     * @param $filename Path to the file.
+     * @param $data Data as String.
+     *
+     * @return Number of Bytes written.
+     */
     static function append($filename, $data)
     {
         return static::getDefaultContext()->append($filename, $data);
     }
 
-    # Creates a temporary file and returns a Stream instance.
-    #
-    # Returns a new Stream.
+    /**
+     * Creates a temporary file and returns a Stream instance.
+     *
+     * @return Stream a new Stream.
+     */
     static function tempfile()
     {
         return new Stream(tmpfile());
     }
 
-    # Returns the script's Error Stream.
+    /**
+     * @return Stream the script's Error Stream.
+     */
     static function stderr()
     {
         static $stderr;
         return $stderr ?: $stderr = static::open("php://stderr");
     }
 
-    # Returns the script's Standard Output Stream.
+    /**
+     * @return Stream the script's Standard Output Stream.
+     */
     static function stdout()
     {
         static $stdout;
         return $stdout ?: $stdout = static::open("php://stdout");
     }
 
-    # Returns the script's Input Stream.
+    /**
+     * @return Stream the script's Input Stream.
+     */
     static function stdin()
     {
         static $stdin;
         return $stdin ?: $stdin = static::open("php://stdin");
     }
 
-    # Returns information about the filename.
-    #
-    # filename - Filename as String.
-    #
-    # Returns a Stat instance containing information about the filename.
+    /**
+     * Returns information about the filename.
+     *
+     * @param $filename Filename as String.
+     *
+     * @return Stat a Stat instance containing information about the filename.
+     */
     static function stat($filename)
     {
         $stats = \stat($filename);
         return new Stat($stats);
     }
 
-    # Returns a pair of interconnected UNIX sockets.
+    /**
+     * @return a pair of interconnected UNIX sockets.
+     */
     static function pipe()
     {
         return Socket::pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
     }
 
-    # Factory for Selectors.
-    #
-    # Returns a new Selector.
+    /**
+     * Factory for Selectors.
+     *
+     * @return Selector a new Selector.
+     */
     static function select()
     {
         return new Selector;

--- a/lib/OOIO/IO.php
+++ b/lib/OOIO/IO.php
@@ -106,7 +106,8 @@ class IO
      * 
      * @return Stream
      */
-    public static function memory($useTemp = true, $initWith = null) {
+    public static function memory($useTemp = true, $initWith = null) 
+    {
         $stream = static::open($useTemp ? "php://temp" : "php://memory", "w+b");
         if ($initWith) {
             $stream->write($initWith);

--- a/lib/OOIO/Interfaces.php
+++ b/lib/OOIO/Interfaces.php
@@ -30,6 +30,8 @@ interface Closeable
 
 interface FileDescriptor
 {
-    # Returns the wrapped system file descriptor for the stream.
+    /**
+     * @return the wrapped system file descriptor for the stream.
+     */
     function toFileDescriptor();
 }

--- a/lib/OOIO/Selector.php
+++ b/lib/OOIO/Selector.php
@@ -2,23 +2,24 @@
 
 namespace OOIO;
 
-# Public: Watches stream instances for stream events.
-#
-# Examples
-#
-#   <?php
-#   use OOIO\Selector,
-#       OOIO\IO;
-#
-#   $select = new Selector;
-#   $select->register(IO::stdin(), 'r');
-#
-#   list($r) = $selector->select();
-#
-#   if ($r) {
-#       echo "You entered ".$r[0]->gets()."\n";
-#   }
-#
+/**
+ * Public: Watches stream instances for stream events.
+ *
+ * Examples
+ *
+ *   <?php
+ *   use OOIO\Selector,
+ *       OOIO\IO;
+ *
+ *   $select = new Selector;
+ *   $select->register(IO::stdin(), 'r');
+ *
+ *   list($r) = $selector->select();
+ *
+ *   if ($r) {
+ *       echo "You entered ".$r[0]->gets()."\n";
+ *   }
+ */
 class Selector
 {
     const
@@ -26,35 +27,49 @@ class Selector
         WATCH_WRITE = 'w',
         WATCH_EXCEPT = 'e',
 
-        # Use this timeout value to return immediately from
-        # the select() call, even when no stream is ready.
+        /**
+         * Use this timeout value to return immediately from
+         * the select() call, even when no stream is ready.
+         */
         TV_NOWAIT = 0;
 
     protected
-        # List of streams to watch for becoming readable.
+        /**
+         * List of streams to watch for becoming readable.
+         */
         $read = array(),
 
-        # List of streams to watch for becoming writable.
+        /**
+         * List of streams to watch for becoming writable.
+         */
         $write = array(),
 
-        # List of streams to watch for errors.
+        /**
+         * List of streams to watch for errors.
+         */
         $except = array(),
 
-        # Maps file descriptors to stream instances.
+        /**
+         * Maps file descriptors to stream instances.
+         */
         $streams = array();
 
-    # Checks which registered streams are ready.
-    #
-    # timeout - Timeout in microseconds.
-    #
-    # Returns the readable, writeable and error'd streams as three lists.
+    /**
+     * Checks which registered streams are ready.
+     *
+     * @param $timeout Timeout in microseconds.
+     *
+     * @return array the readable, writeable and error'd streams as three lists.
+     */
     function select($timeout = null)
     {
         $read = $this->read;
         $write = $this->write;
         $except = $this->except;
 
-        # Response is a list of read, write, except lists of streams (in that order).
+        /**
+         * Response is a list of read, write, except lists of streams (in that order).
+         */
         $resp = array(array(), array(), array());
 
         @stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout);
@@ -74,29 +89,31 @@ class Selector
         return $resp;
     }
 
-    # Public: Registers the stream.
-    #
-    # stream - Stream instance.
-    # modes  - A string of mode(s). Valid modes include:
-    #            r: Monitor for data available.
-    #            w: Monitor for data writeable.
-    #            e: Monitor for errors.
-    #
-    # Examples
-    #
-    #   $select = IO::select();
-    #   $pipe = IO::pipe();
-    #
-    #   $select->register($pipe[1], 'r');
-    #
-    #   $pipe[0]->puts("Hello World!");
-    #
-    #   list($readable) = $s->select(0);
-    #
-    #   echo count($readable);
-    #   # Output:
-    #   # 1
-    #
+    /**
+     * Public: Registers the stream.
+     *
+     * @param $stream Stream instance.
+     * @param $modes A string of mode(s). Valid modes include:
+     *            r: Monitor for data available.
+     *            w: Monitor for data writeable.
+     *            e: Monitor for errors.
+     *
+     * Examples
+     *
+     *   $select = IO::select();
+     *   $pipe = IO::pipe();
+     *
+     *   $select->register($pipe[1], 'r');
+     *
+     *   $pipe[0]->puts("Hello World!");
+     *
+     *   list($readable) = $s->select(0);
+     *
+     *   echo count($readable);
+     *   # Output:
+     *   # 1
+     *
+     */
     function register(FileDescriptor $stream, $modes)
     {
         $fd = $stream->toFileDescriptor();
@@ -117,18 +134,21 @@ class Selector
             }
         }
 
-        # Store the stream instance, so we can return it in select()
-        # instead of the FD.
+        /**
+         * Store the stream instance, so we can return it in select()
+         * instead of the FD.
+         */
         $this->streams[(int) $fd] = $stream;
 
         return $this;
     }
 
-    # Public: Unregister the stream instance.
-    #
-    # stream - Stream to unregister.
-    #
-    # Returns Nothing.
+    /**
+     * Public: Unregister the stream instance.
+     *
+     * @param $stream Stream to unregister.
+     *
+     */
     function unregister(FileDescriptor $stream)
     {
         $fd = $stream->toFileDescriptor();

--- a/lib/OOIO/Stat.php
+++ b/lib/OOIO/Stat.php
@@ -30,7 +30,10 @@ class Stat
 
         } else if (is_resource($stream)) {
             $this->load(\fstat($stream));
-
+        } else if ($stream instanceof FileDescriptor) {
+            $this->load(\fstat($stream->toFileDescriptor()));
+        } else if (is_array($stream)) {
+            $this->load($stream);
         } else {
             throw new \InvalidArgumentException(sprintf(
                 "Constructor expects either a file name or a resource."

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -271,4 +271,19 @@ class Stream
     {
         if ($this->closed) throw new ClosedException("Stream is already closed.");
     }
+    
+    
+    public function filterAdd($append, $filtername, $read_write = null, $params = null) {
+        $this->assertNotClosed();
+        if ($append) return stream_filter_append($this->stream, $filtername, $read_write, $params);
+        else return stream_filter_prepend($this->stream, $filtername, $read_write, $params);
+    }
+
+    public function filterAppend($filtername, $read_write = null, $params = null) {
+        return $this->filterAdd(true, $filtername, $read_write, $params);
+    }    
+
+    public function filterPrepend($filtername, $read_write = null, $params = null) {
+        return $this->filterAdd(false, $filtername, $read_write, $params);
+    }    
 }

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -53,9 +53,10 @@ class Stream
      *
      * @return the total count of bytes copied.
      */
-    function copy(FileDescriptor $fd)
+    function copy(FileDescriptor $fd, $maxLength = -1, $offset = 0)
     {
-        return stream_copy_to_stream($this->stream, $fd->toFileDescriptor());
+        if ($maxLength === null) $maxLength = -1;
+        return stream_copy_to_stream($this->stream, $fd->toFileDescriptor(), $maxLength, $offset);
     }
 
     /**
@@ -70,6 +71,9 @@ class Stream
     {
         $this->assertNotClosed();
 
+        if ($data instanceof Stream) return $this->copy($data, $length);
+        if ($length < 0) $length = null;
+        
         if ($length === null) {
             $bytes = fwrite($this->stream, (string) $data);
         } else {
@@ -134,7 +138,7 @@ class Stream
     {
         $this->assertNotClosed();
 
-        if ($length === null) {
+        if ($length === null || $length < 0) {
             return stream_get_contents($this->stream);
         }
         return fread($this->stream, $length);

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -198,6 +198,12 @@ class Stream
         return rewind($this->stream);
     }
 
+    public function tell() 
+    {
+        $this->assertNotClosed();
+        return ftell($this->stream);
+    }
+    
     /**
      * Flushs the write buffer.
      *

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -12,10 +12,12 @@ class Stream
         $stream,
         $closed = false;
 
-    # Initializes the stream with a resource created by one of
-    # PHP's stream functions.
-    #
-    # stream - Stream resource.
+    /**
+     * Initializes the stream with a resource created by one of
+     * PHP's stream functions.
+     *
+     * @param $stream Stream resource.
+     */
     function __construct($stream)
     {
         if ($stream instanceof FileDescriptor) $stream = $stream->toFileDescriptor();
@@ -43,23 +45,27 @@ class Stream
         return $this->stream;
     }
 
-    # Copies the contents of this stream over to the
-    # other stream.
-    #
-    # fd - Object implementing the FileDescriptor interface.
-    #
-    # Returns the total count of bytes copied.
+    /**
+     * Copies the contents of this stream over to the
+     * other stream.
+     *
+     * @param $fd Object implementing the FileDescriptor interface.
+     *
+     * @return the total count of bytes copied.
+     */
     function copy(FileDescriptor $fd)
     {
         return stream_copy_to_stream($this->stream, $fd->toFileDescriptor());
     }
 
-    # Writes the bytes to the stream.
-    #
-    # dataa  - Bytes to write.
-    # length - Length to write (default: all).
-    #
-    # Returns the number of bytes written, or False on error.
+    /**
+     * Writes the bytes to the stream.
+     *
+     * @param $dataa Bytes to write.
+     * @param $length Length to write (default: all).
+     *
+     * @return the number of bytes written, or False on error.
+     */
     function write($data, $length = null)
     {
         $this->assertNotClosed();
@@ -77,45 +83,53 @@ class Stream
         return $bytes;
     }
 
-    # Writes the string to the stream, delimited by a line separator.
-    #
-    # data      - Data as String.
-    # separator - Separator which should get appended to data (default: PHP_EOL).
-    #
-    # Returns the number of bytes written or False on error.
+    /**
+     * Writes the string to the stream, delimited by a line separator.
+     *
+     * @param $data Data as String.
+     * @param $separator Separator which should get appended to data (default: PHP_EOL).
+     *
+     * @return the number of bytes written or False on error.
+     */
     function puts($data, $separator = PHP_EOL)
     {
         $this->assertNotClosed();
         return $this->write($data . $separator);
     }
 
-    # Writes a formatted string to the stream.
-    #
-    # format - Format String, see the printf() function.
-    # args   - Array of variables.
-    #
-    # Returns the length of the content.
+    /**
+     * Writes a formatted string to the stream.
+     *
+     * @param $format Format String, see the printf() function.
+     * @param $args Array of variables.
+     *
+     * @return the length of the content.
+     */
     function printf($format, $args = array())
     {
         return vfprintf($this->stream, $format, $args);
     }
 
-    # Parses input from the stream according to the format.
-    #
-    # format - String of format specifiers, see the printf() function.
-    #
-    # Returns the parsed variables as Array.
+    /**
+     * Parses input from the stream according to the format.
+     *
+     * @param $format String of format specifiers, see the printf() function.
+     *
+     * @return array the parsed variables as Array.
+     */
     function scanf($format)
     {
         return fscanf($this->stream, $format);
     }
 
-    # Reads from the stream.
-    #
-    # length - Optional, reads everything up to EOF when Null,
-    #          reads {n} bytes when an positive integer.
-    #
-    # Returns a String or False on error.
+    /**
+     * Reads from the stream.
+     *
+     * @param $length Optional, reads everything up to EOF when Null,
+     *          reads {n} bytes when an positive integer.
+     *
+     * @return a String or False on error.
+     */
     function read($length = null)
     {
         $this->assertNotClosed();
@@ -126,21 +140,23 @@ class Stream
         return fread($this->stream, $length);
     }
 
-    # Reads from the stream until a separator (newline) occurs.
-    #
-    # length - Optional, number of max bytes to read.
-    #
-    # Returns a String or False on error.
+    /** Reads from the stream until a separator (newline) occurs.
+     * @param $length - Optional, number of max bytes to read.
+     * 
+     * @return string a String or False on error.
+     */
     function gets($length = null)
     {
         $this->assertNotClosed();
         return $length === null ? fgets($this->stream) : fgets($this->stream, $length);
     }
 
-    # Checks if two stream instances are equal by comparing the
-    # wrapped file descriptors.
-    #
-    # Returns True or False.
+    /**
+     * Checks if two stream instances are equal by comparing the
+     * wrapped file descriptors.
+     *
+     * @return True or False.
+     */
     function equalTo($stream)
     {
         return $this->stream === $stream->stream;
@@ -152,18 +168,20 @@ class Stream
         return feof($this->stream);
     }
 
-    # Seeks to the given offset within the stream.
-    #
-    # offset - Offset in Bytes.
-    # whence - How the offset is handled:
-    #          SEEK_SET (default):
-    #            Set position equal to `offset` bytes.
-    #          SEEK_CUR:
-    #            Set the position to the current location plus `offset`.
-    #          SEEK_END:
-    #            Set position to End-of-file plus `offset`.
-    #
-    # Returns 0 on success, -1 on failure.
+    /**
+     * Seeks to the given offset within the stream.
+     *
+     * @param $offset Offset in Bytes.
+     * @param $whence How the offset is handled:
+     *          SEEK_SET (default):
+     *            Set position equal to `offset` bytes.
+     *          SEEK_CUR:
+     *            Set the position to the current location plus `offset`.
+     *          SEEK_END:
+     *            Set position to End-of-file plus `offset`.
+     *
+     * @return 0 on success, -1 on failure.
+     */
     function seek($offset, $whence = SEEK_SET)
     {
         $this->assertNotClosed();
@@ -176,27 +194,32 @@ class Stream
         return rewind($this->stream);
     }
 
-    # Flushs the write buffer.
-    #
-    # Returns a Bool.
+    /**
+     * Flushs the write buffer.
+     *
+     * @return a Bool.
+     */
     function flush()
     {
         $this->assertNotClosed();
         return fflush($this->stream);
     }
 
-    # Get information about the stream.
-    #
-    # Returns an instance of Jack\IO\Stat.
+    /**
+     * Get information about the stream.
+     *
+     * @return Stat an instance of Jack\IO\Stat.
+     */
     function stat()
     {
         $stats = fstat($this->stream);
         return new Stat($stats);
     }
 
-    # Closes the stream.
-    #
-    # Returns Nothing.
+    /**
+     * Closes the stream.
+     *
+     */
     function close()
     {
         if (fclose($this->stream)) {
@@ -204,17 +227,21 @@ class Stream
         }
     }
 
-    # Checks if the closed flag is set.
-    #
-    # Returns True when the Stream is already closed, False otherwise.
+    /**
+     * Checks if the closed flag is set.
+     *
+     * @return True when the Stream is already closed, False otherwise.
+     */
     function isClosed()
     {
         return $this->closed;
     }
 
-    # Checks if the file descriptor is a Terminal Type Device. Needs the "posix" extension.
-    #
-    # Returns True or False.
+    /**
+     * Checks if the file descriptor is a Terminal Type Device. Needs the "posix" extension.
+     *
+     * @return True or False.
+     */
     function isTty()
     {
         return posix_isatty($this->stream);
@@ -225,10 +252,11 @@ class Stream
         stream_set_blocking($this->stream, (int) $mode);
     }
 
-    # Throws an ClosedException when the Stream was closed
-    # by `close()`.
-    #
-    # Returns Nothing.
+    /**
+     * Throws an ClosedException when the Stream was closed
+     * by `close()`.
+     *
+     */
     protected function assertNotClosed()
     {
         if ($this->closed) throw new ClosedException("Stream is already closed.");

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -18,6 +18,8 @@ class Stream
     # stream - Stream resource.
     function __construct($stream)
     {
+        if ($stream instanceof FileDescriptor) $stream = $stream->toFileDescriptor();
+        
         if (!is_resource($stream)) {
             throw new InvalidArgumentException(
                 "Constructor expects a valid resource as first argument."

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -29,6 +29,15 @@ class Stream
         $this->stream = $stream;
     }
 
+    /** 
+     * Ensures the Stream wrapper on the object/descriptor
+     * @return Stream
+     */
+    public static function ensure($stream) {
+        if ($stream instanceof Stream) return $stream;
+        return new Stream($stream);
+    }    
+    
     function toFileDescriptor()
     {
         return $this->stream;

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -49,15 +49,21 @@ class Stream
      * Copies the contents of this stream over to the
      * other stream.
      *
-     * @param $fd Object implementing the FileDescriptor interface.
+     * @param $destination Copy destination object implementing the FileDescriptor interface.
      *
      * @return the total count of bytes copied.
      */
-    function copy(FileDescriptor $fd, $maxLength = -1, $offset = 0)
+    function copy(FileDescriptor $destination, $maxLength = -1, $offset = 0)
     {
         if ($maxLength === null) $maxLength = -1;
-        return stream_copy_to_stream($this->stream, $fd->toFileDescriptor(), $maxLength, $offset);
+        return stream_copy_to_stream($this->stream, $destination->toFileDescriptor(), $maxLength, $offset);
     }
+    
+    function copyFrom(FileDescriptor $source, $maxLength = -1, $offset = 0)
+    {
+        if ($maxLength === null) $maxLength = -1;
+        return stream_copy_to_stream($source->toFileDescriptor(), $this->stream, $maxLength, $offset);
+    }    
 
     /**
      * Writes the bytes to the stream.
@@ -71,7 +77,7 @@ class Stream
     {
         $this->assertNotClosed();
 
-        if ($data instanceof Stream) return $this->copy($data, $length);
+        if ($data instanceof FileDescriptor) return $this->copyFrom($data, $length);
         if ($length < 0) $length = null;
         
         if ($length === null) {

--- a/lib/OOIO/Stream.php
+++ b/lib/OOIO/Stream.php
@@ -35,7 +35,8 @@ class Stream
      * Ensures the Stream wrapper on the object/descriptor
      * @return Stream
      */
-    public static function ensure($stream) {
+    public static function ensure($stream) 
+    {
         if ($stream instanceof Stream) return $stream;
         return new Stream($stream);
     }    
@@ -279,17 +280,23 @@ class Stream
     }
     
     
-    public function filterAdd($append, $filtername, $read_write = null, $params = null) {
+    public function filterAdd($append, $filterName, $readWrite = null, $params = null) 
+    {
         $this->assertNotClosed();
-        if ($append) return stream_filter_append($this->stream, $filtername, $read_write, $params);
-        else return stream_filter_prepend($this->stream, $filtername, $read_write, $params);
+        if ($append) {
+            return stream_filter_append($this->stream, $filterName, $readWrite, $params);
+        } else {
+            return stream_filter_prepend($this->stream, $filterName, $readWrite, $params);
+        }
     }
 
-    public function filterAppend($filtername, $read_write = null, $params = null) {
-        return $this->filterAdd(true, $filtername, $read_write, $params);
+    public function filterAppend($filterName, $readWrite = null, $params = null) 
+    {
+        return $this->filterAdd(true, $filterName, $readWrite, $params);
     }    
 
-    public function filterPrepend($filtername, $read_write = null, $params = null) {
-        return $this->filterAdd(false, $filtername, $read_write, $params);
+    public function filterPrepend($filterName, $readWrite = null, $params = null) 
+    {
+        return $this->filterAdd(false, $filterName, $readWrite, $params);
     }    
 }

--- a/lib/OOIO/StreamContext.php
+++ b/lib/OOIO/StreamContext.php
@@ -5,12 +5,16 @@ namespace OOIO;
 class StreamContext
 {
     protected
-        # Context Resource created with `stream_context_create()`.
+        /**
+         * Context Resource created with `stream_context_create()`.
+         */
         $context;
 
-    # Initialized the instance with a stream context resource.
-    #
-    # context - Stream context resource, created by `stream_context_create`.
+    /**
+     * Initialized the instance with a stream context resource.
+     *
+     * @param $context Stream context resource, created by `stream_context_create`.
+     */
     function __construct($context = null)
     {
         if (null === $context) {
@@ -29,13 +33,15 @@ class StreamContext
         stream_context_set_params($this->context, $params);
     }
 
-    # Reads content from the filename.
-    #
-    # filename  - String.
-    # maxLength - Number of bytes to read.
-    # offset    - Where to start.
-    #
-    # Returns the content as String.
+    /**
+     * Reads content from the filename.
+     *
+     * @param $filename String.
+     * maxLength - Number of bytes to read.
+     * @param $offset Where to start.
+     *
+     * @return the content as String.
+     */
     function read($filename, $maxLength = null, $offset = -1)
     {
         if ($maxLength === null) {
@@ -47,43 +53,48 @@ class StreamContext
         return $data;
     }
 
-    # Replaces the file's contents with the provided data.
-    #
-    # filename - File Name as String.
-    # data     - String, the new content for the file.
-    # flags    - Flags:
-    #            FILE_USE_INCLUDE_PATH: Search for the filename in the 
-    #            include path.
-    #            FILE_APPEND: If the filename already exists, append the 
-    #            data to the file.
-    #            LOCK_EX: Aquire an exclusive lock.
-    #
-    # Returns Number of Bytes written or False.
+    /**
+     * Replaces the file's contents with the provided data.
+     *
+     * @param $filename File Name as String.
+     * @param $data String, the new content for the file.
+     * @param $flags Flags:
+     *            FILE_USE_INCLUDE_PATH: Search for the filename in the 
+     *            include path.
+     *            FILE_APPEND: If the filename already exists, append the 
+     *            data to the file.
+     *            LOCK_EX: Aquire an exclusive lock.
+     *
+     * @return Number of Bytes written or False.
+     */
     function write($filename, $data, $flags = 0)
     {
         return file_put_contents($filename, $data, $flags, $this->context);
     }
 
-    # Appends the data to the file's contents.
-    #
-    # filename - File Name as String.
-    # data     - String, gets written to the file.
-    #
-    # Returns Number of Bytes written or False.
+    /**
+     * Appends the data to the file's contents.
+     *
+     * @param $filename File Name as String.
+     * @param $data String, gets written to the file.
+     *
+     * @return Number of Bytes written or False.
+     */
     function append($filename, $data)
     {
         return $this->write($filename, $data, FILE_APPEND);
     }
 
-    # Opens the file.
-    #
-    # filename - File name as String.
-    # mode     - Open mode, same as for `fopen`.
-    # callback - Optional callback, gets passed the Stream instance. The Stream
-    #            gets closed after the callback returned.
-    #
-    # Returns the Stream when no callback was passed, otherwise returns the callback's
-    # return value.
+    /**
+     * Opens the file.
+     * 
+     * @param $filename File name as String.
+     * @param $mode Open mode, same as for `fopen`.
+     * @param $callback Optional callback, gets passed the Stream instance. The Stream
+     *          gets closed after the callback returned.
+     * Returns the Stream when no callback was passed, otherwise returns the callback's return value.
+     * @return Stream
+     */
     function open($filename, $mode = "", $callback = null)
     {
         $fd = fopen($filename, $mode, false, $this->context);

--- a/tests/OOIO/Test/StreamTest.php
+++ b/tests/OOIO/Test/StreamTest.php
@@ -38,4 +38,40 @@ class StreamTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("Hello World", $this->stream->read());
     }
+    
+    function testMemory()
+    {
+        $string = 'fooBAR';
+        $stream = \OOIO\IO::memory(false, $string);
+        
+        $this->assertEquals($string, $stream->read());
+        $this->assertEquals(strlen($string), $stream->stat()->size);
+        $this->assertEquals(strlen($string), $stream->tell());
+        
+        $stream->seek(3);
+        $this->assertEquals(substr($string, 3), $stream->read());
+        
+        $stream->seek(3);
+        $stream2 = \OOIO\IO::memory(false, $stream);
+        $this->assertEquals(substr($string, 3), $stream2->read());
+    }
+    
+    function testCopy() 
+    {
+        $this->stream->write("Hello World");
+        $this->stream->rewind();
+        
+        $stream2 = \OOIO\IO::memory();
+        
+        $this->stream->copy($stream2, 5);
+        
+        $stream2->rewind();
+        $this->assertEquals('Hello', $stream2->read());
+        
+        $stream2->copyFrom($this->stream);
+        
+        $stream2->rewind();
+        $this->assertEquals('Hello World', $stream2->read());
+    }
+    
 }


### PR DESCRIPTION
I've refactored comments to more standard `/***/` syntax with phpdoc for IDEs.

Plus there are a couple of additional functions. More will follow
